### PR TITLE
Fix analyze button loading state

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -86,6 +86,7 @@ export default function Home() {
             description: "Please log in to analyze charts.",
             variant: "destructive",
           });
+          setIsLoading(false);
         }
         return;
       }
@@ -97,6 +98,7 @@ export default function Home() {
             description: "Chart data is not loaded yet. Please wait.",
             variant: "destructive",
           });
+          setIsLoading(false);
         }
         return;
       }


### PR DESCRIPTION
Reset `isLoading` state on early returns in `handleAnalyze` to prevent the analyze button from getting stuck.

The analyze button would remain in a loading state if the `handleAnalyze` function exited early (e.g., user not authenticated, no chart data) without explicitly setting `isLoading` to `false`. This change ensures the UI accurately reflects the button's state.

---
<a href="https://cursor.com/background-agent?bcId=bc-cef15a71-3c00-4636-beea-ba1f18a5ae0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cef15a71-3c00-4636-beea-ba1f18a5ae0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

